### PR TITLE
1.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install via [Wally](https://wally.run), add the following to your `wally.toml
 
 ```toml
 [dependencies]
-roxios = "fxllencode/roxios@1.1.7"
+roxios = "fxllencode/roxios@1.1.8"
 ```
 
 Then, run `wally install` to install the dependencies.

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fxllencode/roxios"
-version = "1.1.7"
+version = "1.1.8"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
# Update - v1.1.8

## Changes

* Fixed support as a Wally package. 
* 
## Upgrading

### With Wally

Update your `wally.toml` file to:

```toml
[dependencies]

roxios = "fxllencode/roxios@1.1.8"
```

### With .rbxm

Head to the [releases](https://github.com/FxllenCode/roxios/releases) page to download the latest version, and drag `pack.rbxm` into `ReplicatedStorage`. Ensure you replace your other version of Roxios.

### Building from Source Code with Foreman

Inside your git repository, run `git pull`, or `git fetch`. Then, run the build command again:

```bash
rojo build -o pack.rbxm pack.project.json
```